### PR TITLE
Configure Netlify build for Next.js

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,12 @@
+[build]
+  command = "pnpm run build"
+  publish = ".next"
+
+[build.environment]
+  PNPM_VERSION = "9.12.3"
+
+[dev]
+  command = "pnpm run dev"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev:web": "NEXT_USE_TURBOPACK=0 WATCHPACK_POLLING=true BROWSER=none next dev -p 3000 --hostname 0.0.0.0",
     "dev:detached": "nohup sh -c 'NEXT_USE_TURBOPACK=0 WATCHPACK_POLLING=true BROWSER=none next dev -p 3000 --hostname 0.0.0.0' > .next/dev.out 2>&1 & echo $! > .next/dev.pid",
     "dev:stop": "kill -9 $(cat .next/dev.pid) 2>/dev/null && rm -f .next/dev.pid || true",
-    "build": "next build --turbopack",
+    "build": "next build",
     "start": "next start -p 3000 -H 0.0.0.0",
     "lint": "eslint"
   },


### PR DESCRIPTION
## Summary
- add a Netlify configuration file so the build runs with pnpm and the official Next.js adapter
- switch the build script to use the standard `next build` command for compatibility with Netlify

## Testing
- pnpm run build *(fails in sandbox because Google Fonts cannot be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68db28c2f1d0832bbfbee298c6e22ce6