### PR TITLE
fix: correct Tailwind v4 PostCSS plugin usage

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,9 @@
 [build]
   command = "pnpm run build"
-  publish = ".next"
 
 [build.environment]
   PNPM_VERSION = "9.12.3"
+  NODE_VERSION = "20"
 
 [dev]
   command = "pnpm run dev"

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,13 +1,6 @@
-import tailwindcss from "@tailwindcss/postcss";
-
-const config = {
+/** @type {import('postcss-load-config').Config} */
+export default {
   plugins: {
-
-    tailwindcss,
-
     "@tailwindcss/postcss": {},
-
   },
 };
-
-export default config;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,7 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
 :root {
   --brand: #1E88E5;


### PR DESCRIPTION
## Summary
- replace the PostCSS configuration with the Tailwind CSS v4 plugin format
- ensure global styles begin with the Tailwind layer directives and keep Google font import after them
- simplify Netlify build configuration while pinning Node and PNPM versions for Next.js builds

## Testing
- `pnpm run build` *(fails: Next.js cannot download Google Fonts in this offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3daa8910832bb24134c686faec47